### PR TITLE
カテゴリを消した場合、関連したノートが表示されないバグを修正

### DIFF
--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -20,7 +20,7 @@
   <%= text_field_tag :title, @note.title, class: "form-control title-field" %>
   内容
   <%= text_area_tag :content, @note.content, class: "form-control content-field" %>
-  <%= select_tag :category_id, options_from_collection_for_select(Category.where(user: current_user), :id, :name) %>
+  <%= select_tag :category_id, options_from_collection_for_select(Category.where(user: current_user), :id, :name, @note.category_id) %>
   <%= submit_tag "保存", class: "btn primary-btn" %>
 <% end %>
 

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -11,7 +11,9 @@
       <p>タイトル</p>
       <span class="content">
         <%= link_to note.title, note_path(note.id) %>
-        <%= note.category.name  %>
+        <% if note.category != nil %>
+          <%= note.category.name  %>
+        <% end %>  
         <%= note.user.name%>
         <% if current_user != nil && current_user.id == note.user_id  %>
           <%= link_to "編集", edit_note_path(note.id), class: "btn edit-btn" %>     

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -6,7 +6,9 @@
 <h2>タイトル</h2>
 <p><%= @note.title %></p>
 <h2>カテゴリ</h2>
-<p><%= @note.category_id %></p>
+<% if @note.category != nil %>
+  <p><%= @note.category.name %></p>
+<% end %>
 <h2>記事内容</h2>
 <p><%= @note.content %></p>
 


### PR DESCRIPTION
# TODO
- [x] カテゴリ消した場合、関連したノートが表示されなくなるバグを修正。
  ノートのcategory_idはバリデーションで presence: :trueとなっているので、記事を編集したい場合は新たにタグを指定しなくてはならない。
- [x] ノートの詳細ページにてカテゴリIDではなくカテゴリ名が表示される。
